### PR TITLE
Fix test script dev server cleanup

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -29,7 +29,7 @@ npm run build
 PORT=5173 npm run dev >/tmp/vite.log 2>&1 &
 VITE_PID=$!
 sleep 5
-kill $VITE_PID
+kill $VITE_PID || true
 cd ..
 
 # install python dependencies for tests


### PR DESCRIPTION
## Summary
- ignore errors when killing the Vite dev server in `test.sh`

## Testing
- `bash test.sh`

------
https://chatgpt.com/codex/tasks/task_e_685095c99e40832083c0837c197c5489