### PR TITLE
Stabil E2E: GraphQL, PDF, filopplasting, CORS, CI & E2E

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,7 @@
 JWT_SECRET=
 PORT=8000
 DEMO_MODE=false
+GRAPHQL_URL=http://localhost:9000/graphql
+PDF_SERVICE_URL=http://localhost:9001/generate
+ALLOW_ORIGIN=http://localhost:5173
+FILE_UPLOAD_MAX_MB=50

--- a/backend/gateway/index.js
+++ b/backend/gateway/index.js
@@ -18,6 +18,7 @@ const typeDefs = `#graphql
 
   type Query {
     health: String!
+    allSchools: [School!]!
     school(id: ID!): School
     compareSchools(ids: [ID!]!): [School!]!
   }
@@ -70,6 +71,7 @@ const schools = [
 const resolvers = {
   Query: {
     health: () => 'ok',
+    allSchools: () => schools,
     school: (_, { id }) => schools.find((s) => s.id === id) || null,
     compareSchools: (_, { ids }) => schools.filter((s) => ids.includes(s.id)),
   },

--- a/frontend/src/apollo/client.ts
+++ b/frontend/src/apollo/client.ts
@@ -1,7 +1,10 @@
 import { ApolloClient, InMemoryCache, HttpLink } from '@apollo/client';
 
+// Allow overriding the GraphQL endpoint at build time via VITE_GRAPHQL_URL
+const uri = import.meta.env.VITE_GRAPHQL_URL || '/graphql';
+
 const client = new ApolloClient({
-  link: new HttpLink({ uri: '/graphql' }),
+  link: new HttpLink({ uri }),
   cache: new InMemoryCache(),
 });
 


### PR DESCRIPTION
## Summary
- expose `allSchools` query in GraphQL gateway
- allow frontend GraphQL client to use `VITE_GRAPHQL_URL`
- document common service URLs in `.env.example`

## Testing
- `npm run build`
- `./env-check.sh`
- `./build-check.sh`
- `./test.sh`
- `pytest backend -q`


------
https://chatgpt.com/codex/tasks/task_e_68afe81898e88320b7f66e78ada10d05